### PR TITLE
Package.json now correctly directs the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "element"
   ],
   "homepage": "https://github.com/d3fc/d3fc-element",
+  "main" : "build/d3fc-element.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/d3fc/d3fc-element"


### PR DESCRIPTION
- Added "main" option for directing the build in package.json

This resolves issue #22 